### PR TITLE
Parameterize argo helm

### DIFF
--- a/charts/argo/templates/ui-service.yaml
+++ b/charts/argo/templates/ui-service.yaml
@@ -14,4 +14,4 @@ spec:
   selector:
     app: {{ .Release.Name }}-{{ .Values.uiName}}
   sessionAffinity: None
-  type: LoadBalancer
+  type: {{ .Values.uiServiceType }}

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -18,14 +18,14 @@ data:
       s3:
         {{- if .Values.useStaticCredentials }}
         accessKeySecret:
-          key: {{ .Values.artifactAccessKeySecret }}
-          name: {{ .Values.artifactSecretName | default (printf "%s-%s" .Release.Name "minio-user") }}
+          key: {{ .Values.artifactRepository.s3.accessKeySecret.key }}
+          name: {{ .Values.artifactRepository.s3.accessKeySecret.name | default (printf "%s-%s" .Release.Name "minio-user") }}
         secretKeySecret:
-          key: {{ .Values.artifactSecretKeySecret }}
-          name: {{ .Values.artifactSecretName | default (printf "%s-%s" .Release.Name "minio-user") }}
+          key: {{ .Values.artifactRepository.s3.secretKeySecret.key }}
+          name: {{ .Values.artifactRepository.s3.secretKeySecret.name | default (printf "%s-%s" .Release.Name "minio-user") }}
         {{- end }}
-        bucket: {{ .Values.artifactBucketName | default .Values.minioBucketName }}
-        endpoint: {{ .Values.artifactEndpoint | default (printf "%s-%s" .Release.Name "minio-svc:9000") }}
-        insecure: {{ .Values.artifactInsecure }}
+        bucket: {{ .Values.artifactRepository.s3.bucket | default .Values.minioBucketName }}
+        endpoint: {{ .Values.artifactRepository.s3.endpoint | default (printf "%s-%s" .Release.Name "minio-svc:9000") }}
+        insecure: {{ .Values.artifactRepository.s3.insecure }}
       {{- end}}
     executorImage: "{{ .Values.imagesNamespace }}/{{ .Values.executorImage }}:{{ .Values.imagesTag }}"

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -1,29 +1,31 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controllerName}}-configmap
+  name: {{ .Release.Name }}-{{ .Values.controllerName }}-configmap
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
   config: |
-{{ if .Values.useReleaseAsInstanceID }}
+    {{- if .Values.useReleaseAsInstanceID }}
     instanceID: {{ .Release.Name }}
-{{ else }}
+    {{- else }}
     instanceID: {{ .Values.instanceID }}
-{{ end }}
+    {{- end }}
     artifactRepository:
-{{ if .Values.installMinio }}
+      {{- if or .Values.installMinio .Values.useDefaultArtifactRepo }}
       s3:
+        {{- if .Values.useStaticCredentials }}
         accessKeySecret:
-          key: accesskey
-          name: {{ .Release.Name }}-minio-user
-        bucket: {{ .Values.minioBucketName }}
-        endpoint: {{ .Release.Name }}-minio-svc:9000
-        insecure: true
+          key: {{ .Values.artifactAccessKeySecret }}
+          name: {{ .Values.artifactSecretName | default (printf "%s-%s" .Release.Name "minio-user") }}
         secretKeySecret:
-          key: secretkey
-          name: {{ .Release.Name }}-minio-user
-{{ end }}
+          key: {{ .Values.artifactSecretKeySecret }}
+          name: {{ .Values.artifactSecretName | default (printf "%s-%s" .Release.Name "minio-user") }}
+        {{- end }}
+        bucket: {{ .Values.artifactBucketName | default .Values.minioBucketName }}
+        endpoint: {{ .Values.artifactEndpoint | default (printf "%s-%s" .Release.Name "minio-svc:9000") }}
+        insecure: {{ .Values.artifactInsecure }}
+      {{- end}}
     executorImage: "{{ .Values.imagesNamespace }}/{{ .Values.executorImage }}:{{ .Values.imagesTag }}"

--- a/charts/argo/templates/workflow-crd.yaml
+++ b/charts/argo/templates/workflow-crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: workflows.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Workflow
+    plural: workflows
+    shortNames:
+    - wf
+  scope: Namespaced
+  version: v1alpha1

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -4,14 +4,23 @@ uiImage: argoui
 executorImage: argoexec
 imagesTag: v2.0.0-alpha3
 controllerName: workflow-controller
+
 # Enables ability to SSH into pod using web UI
 enableWebConsole: false
 uiName: ui
+uiServiceType: LoadBalancer
 crdVersion: v1alpha1
+
 # If set to true then chart set controller instance id to release name
 useReleaseAsInstanceID: false
 instanceID:
 
+useDefaultArtifactRepo: false
+useStaticCredentials: true
+
 # If set to true then chart installs minio and generate according artifactRepository section in workflow controller config map
 installMinio: true
 minioBucketName: argo-artifacts
+artifactAccessKeySecret: accesskey
+artifactSecretKeySecret: secretkey
+artifactInsecure: true

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -21,6 +21,11 @@ useStaticCredentials: true
 # If set to true then chart installs minio and generate according artifactRepository section in workflow controller config map
 installMinio: true
 minioBucketName: argo-artifacts
-artifactAccessKeySecret: accesskey
-artifactSecretKeySecret: secretkey
-artifactInsecure: true
+
+artifactRepository:
+  s3:
+    accessKeySecret:
+      key: accesskey
+    secretKeySecret:
+      key: secretkey
+    insecure: true


### PR DESCRIPTION
**What**
- Parameterize artifact configuration
- Add workflow CRD definition to argo chart

**Why**
The argo helm chart is not parameterized enough for us to be able to deploy to our cluster. It is also missing the custom resource definition (CRD).

**Who**
@malexovi @yayalice 
cc: @darend @dominicbueno 