### PR TITLE
Add ability to not deploy Argo UI

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: argo
-version: 0.1.1
+version: 0.2.0

--- a/charts/argo/templates/ui-deployment.yaml
+++ b/charts/argo/templates/ui-deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.ui.enabled  }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -19,3 +20,4 @@ spec:
           env:
           - name: IN_CLUSTER
             value: "true"
+{{ end }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -5,6 +5,8 @@ executorImage: argoexec
 imagesTag: v2.1.0-alpha1
 controllerName: workflow-controller
 
+ui:
+  enabled: true
 # Enables ability to SSH into pod using web UI
 enableWebConsole: false
 uiName: ui


### PR DESCRIPTION
## Why
We do not use the Argo UI and do not want it deployed due to it having some vulnerabilities that potentially could expose us.

## Who
@wookasz 